### PR TITLE
fix: TaxIdentificationNumberNotFoundException n/a anymore

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -78,13 +78,13 @@ class HttpTransporter implements TransporterContract
 
         }
 
-        if (! array_key_exists('notFound', $response) && ! array_key_exists('Errors', $response)) {
-            return $response;
-        }
+        // if (! array_key_exists('notFound', $response) && ! array_key_exists('Errors', $response)) {
+        //     return $response;
+        // }
 
-        if ($response['notFound'] !== []) {
-            throw new TaxIdentificationNumberNotFoundException();
-        }
+        // if ($response['notFound'] !== []) {
+        //     throw new TaxIdentificationNumberNotFoundException();
+        // }
 
         return $response;
     }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -6,7 +6,6 @@ namespace Anaf\Transporters;
 
 use Anaf\Contracts\TransporterContract;
 use Anaf\Exceptions\FileTypeException;
-use Anaf\Exceptions\TaxIdentificationNumberNotFoundException;
 use Anaf\Exceptions\TransporterException;
 use Anaf\Exceptions\UnserializableResponse;
 use Anaf\ValueObjects\Transporter\BaseUri;
@@ -38,7 +37,6 @@ class HttpTransporter implements TransporterContract
     /**
      * {@inheritDoc}
      *
-     * @throws TaxIdentificationNumberNotFoundException
      * @throws JsonException
      */
     public function requestObject(Payload $payload): array
@@ -77,14 +75,6 @@ class HttpTransporter implements TransporterContract
             $response = json_decode($jsonResponse, true, 512, JSON_THROW_ON_ERROR);
 
         }
-
-        // if (! array_key_exists('notFound', $response) && ! array_key_exists('Errors', $response)) {
-        //     return $response;
-        // }
-
-        // if ($response['notFound'] !== []) {
-        //     throw new TaxIdentificationNumberNotFoundException();
-        // }
 
         return $response;
     }


### PR DESCRIPTION
I believe the TaxIdentificationNumberNotFoundException exception is not needed anymore in HttpTransporter because it conflicts with Anaf\Resources\Info::create().

E.g. I am Anaf\Resources\Info::create() with multiple `cui`s and if one of them is present in the `notFound` array but the rest of them are found, I still get the TaxIdentificationNumberNotFoundException.