### PR TITLE
Fix fatal error of missing @attributes key on upload

### DIFF
--- a/src/Resources/Efactura.php
+++ b/src/Resources/Efactura.php
@@ -41,6 +41,10 @@ class Efactura
         /** @var array<array-key, array{dateResponse: string, ExecutionStatus: string, index_incarcare: string}> $response */
         $response = $this->transporter->requestObject($payload);
 
+        if (! array_key_exists('@attributes', $response)) {
+            throw new RuntimeException($response['message']);
+        }
+
         return CreateUploadResponse::from($response['@attributes']);
     }
 

--- a/tests/Transporters/HttpTransporterObject.php
+++ b/tests/Transporters/HttpTransporterObject.php
@@ -112,30 +112,6 @@ test('request object response', function () {
     );
 });
 
-test('request object tax identification number not found', function () {
-    $payload = Payload::create('PlatitorTvaRest/api/v8/ws/tva', []);
-
-    $response = new Response(200, [], json_encode(
-        [
-            'cod' => 200,
-            'message' => 'SUCCESS',
-            'found' => [],
-            'notFound' => [
-                0 => 387445633,
-            ],
-        ],
-    ));
-
-    $this->client
-        ->shouldReceive('sendRequest')
-        ->once()
-        ->andReturn($response);
-
-    expect(fn () => $this->http->requestObject($payload))
-        ->toThrow(function (TaxIdentificationNumberNotFoundException $e) {
-            expect($e->getMessage())->toBe('Tax identification number not found');
-        });
-});
 
 test('request object client errors', function () {
     $payload = Payload::create('PlatitorTvaRest/api/v8/ws/tva', []);


### PR DESCRIPTION
Sorry pull request template was missing. 

- Handled missing '@attributes' key in \Anaf\Resources\Efactura::upload(). It causes fatal error in cases of Bad Gateway, Unauthorized, etc. responses where this key is missing. 

- Deleted unnecessary test case. The case became unnecessary since:
https://github.com/andalisolutions/anaf-php/commit/a8e56bc6a4c6a3e34fee480dab9e1104c4ad8187
