### PR TITLE
Fix parameter type

### DIFF
--- a/src/Responses/Info/RetrieveResponseGeneralData.php
+++ b/src/Responses/Info/RetrieveResponseGeneralData.php
@@ -18,7 +18,7 @@ class RetrieveResponseGeneralData
         public readonly string $document,
         public readonly string $registrationStatus,
         public readonly string $registrationDate,
-        public readonly string $activityCode,
+        public readonly ?string $activityCode,
         public readonly string $bankAccount,
         public readonly bool $roInvoiceStatus,
         public readonly string $authorityName,


### PR DESCRIPTION
With V9 API version, cod_CAEN comes null instead of empty string for government companies (e.g.: 4331473)